### PR TITLE
Adding destroy method to connection

### DIFF
--- a/lib/thrift/connection.js
+++ b/lib/thrift/connection.js
@@ -98,6 +98,10 @@ Connection.prototype.end = function() {
   this.connection.end();
 }
 
+Connection.prototype.destroy = function() {
+  this.connection.destroy();
+}
+
 Connection.prototype.write = function(data) {
   if (!this.connected) {
     this.offline_queue.push(data);


### PR DESCRIPTION
Adding a `destroy` method to the connection so that write data can be discarded rather than waiting for it to complete.

I'd like destroy: `http://nodejs.org/api/stream.html#stream_stream_destroy_1`

in addition to `end`: http://nodejs.org/api/stream.html#stream_stream_end
